### PR TITLE
Record world hopping chat

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -23,6 +23,7 @@ let captureInterval: NodeJS.Timeout;
 let previousMainContent: string;
 let hasTimestamps: boolean;
 let lastTimestamp: Date;
+let lastMessage: string;
 let ORIGIN = document.location.href;
 
 // DONT FORGET TO CHANGE THIS BACK TO FALSE FOR PRODUCTION \\
@@ -76,6 +77,8 @@ async function readChatFromImage(img: a1lib.ImgRefBind): Promise<void> {
         if (lastTimestamp) lines = lines.filter(line => new Date(`${new Date().toLocaleDateString()} ` + line.fragments[1].text) > lastTimestamp)
 
         for (const line of lines) {
+            if (line.text === lastMessage) continue
+            lastMessage = line.text
             console.log(line)
             
             const allTextFromLine = line.text

--- a/src/app.ts
+++ b/src/app.ts
@@ -85,8 +85,8 @@ async function readChatFromImage(img: a1lib.ImgRefBind): Promise<void> {
                 const time = line.fragments[1]?.text ?? recentTimestamp
 
                 // Send the combined text to the server
+                const current_world = alt1.currentWorld
                 try {
-                    const current_world = alt1.currentWorld
                     const response = await axios.post(
                         "https://i3fhqxgish.execute-api.eu-west-2.amazonaws.com/send_webhook", {
                             method: 'POST',
@@ -134,7 +134,7 @@ async function readChatFromImage(img: a1lib.ImgRefBind): Promise<void> {
                         }
                     }
                 } catch (err) {
-                    console.log("Duplicate event - ignoring.")
+                    console.log(`Duplicate event - ignoring ${matchingEvent} on ${current_world}`)
                 }
             } else if (!partialMatch) {
                 combinedText = ""

--- a/src/app.ts
+++ b/src/app.ts
@@ -63,20 +63,26 @@ async function readChatFromImage(img: a1lib.ImgRefBind): Promise<void> {
         document.querySelector('#mainTab p').innerHTML = previousMainContent
     }
 
-    const lines = chatbox.read(); // Read lines from the detected chat box
+    let lines = chatbox.read(); // Read lines from the detected chat box
     if (!hasTimestamps) lines.some(line => line.fragments.length > 1 && /\d\d:\d\d:\d\d/.test(line.fragments[1].text)) ? hasTimestamps = true : hasTimestamps = false
 
     let combinedText = ""
     let recentTimestamp: null | string = null;
     if (lines?.length) {
+        // Remove blank lines
+        if (lines.some(line => line.text === "")) lines = lines.filter(line => line.text !== "")
+        
+        // Remove all messages which are not older than the lastTimestamp
+        if (lastTimestamp) lines = lines.filter(line => new Date(`${new Date().toLocaleDateString()} ` + line.fragments[1].text) > lastTimestamp)
+
         for (const line of lines) {
-            lastChatMessage = line.text
             console.log(line)
             
             const allTextFromLine = line.text
             combinedText = combinedText === "" ? combinedText += allTextFromLine : combinedText + " " + allTextFromLine
-
+            
             if (hasTimestamps && line.fragments.length > 1) recentTimestamp = line.fragments[1].text
+            lastTimestamp = new Date(`${new Date().toLocaleDateString()} ` + recentTimestamp) ?? new Date()
 
             // Check if the text contains any keywords from the 'events' object
             const [partialMatch, matchingEvent] = getMatchingEvent(combinedText, events);

--- a/src/app.ts
+++ b/src/app.ts
@@ -22,7 +22,8 @@ chatbox.readargs.colors.push(
 let captureInterval: NodeJS.Timeout;
 let previousMainContent: string;
 let hasTimestamps: boolean;
-let ORIGIN = document.location.href
+let lastChatMessage = "";
+let ORIGIN = document.location.href;
 
 // DONT FORGET TO CHANGE THIS BACK TO FALSE FOR PRODUCTION \\
 const DEBUG = false
@@ -69,6 +70,7 @@ async function readChatFromImage(img: a1lib.ImgRefBind): Promise<void> {
     let recentTimestamp: null | string = null;
     if (lines?.length) {
         for (const line of lines) {
+            lastChatMessage = line.text
             console.log(line)
             
             const allTextFromLine = line.text

--- a/src/app.ts
+++ b/src/app.ts
@@ -22,7 +22,7 @@ chatbox.readargs.colors.push(
 let captureInterval: NodeJS.Timeout;
 let previousMainContent: string;
 let hasTimestamps: boolean;
-let lastChatMessage = "";
+let lastTimestamp: Date;
 let ORIGIN = document.location.href;
 
 // DONT FORGET TO CHANGE THIS BACK TO FALSE FOR PRODUCTION \\

--- a/src/app.ts
+++ b/src/app.ts
@@ -71,13 +71,10 @@ async function readChatFromImage(img: a1lib.ImgRefBind): Promise<void> {
         for (const line of lines) {
             console.log(line)
             
-            // If any keyword was found in any fragment, collect all fragment texts
-            const allTextFromLine = line.fragments.map(fragment => fragment.text).join(""); // Join all fragment texts
+            const allTextFromLine = line.text
             combinedText = combinedText === "" ? combinedText += allTextFromLine : combinedText + " " + allTextFromLine
 
-            if (hasTimestamps && line.fragments.length > 1) {
-                recentTimestamp = line.fragments[1].text
-            }
+            if (hasTimestamps && line.fragments.length > 1) recentTimestamp = line.fragments[1].text
 
             // Check if the text contains any keywords from the 'events' object
             const [partialMatch, matchingEvent] = getMatchingEvent(combinedText, events);
@@ -138,7 +135,6 @@ async function readChatFromImage(img: a1lib.ImgRefBind): Promise<void> {
                     console.log("Duplicate event - ignoring.")
                 }
             } else if (!partialMatch) {
-                console.log("reset")
                 combinedText = ""
             }
         }

--- a/src/app.ts
+++ b/src/app.ts
@@ -74,7 +74,8 @@ async function readChatFromImage(img: a1lib.ImgRefBind): Promise<void> {
         if (lines.some(line => line.text === "")) lines = lines.filter(line => line.text !== "")
         
         // Remove all messages which are not older than the lastTimestamp
-        if (lastTimestamp) lines = lines.filter(line => new Date(`${new Date().toLocaleDateString()} ` + line.fragments[1].text) > lastTimestamp)
+        // Messages will not be sent if there are messages which are sent at the same time!
+        if (lastTimestamp) lines = lines.filter(line => new Date(`${new Date().toLocaleDateString()} ` + line.fragments[1]?.text) >= lastTimestamp)
 
         for (const line of lines) {
             if (line.text === lastMessage) continue


### PR DESCRIPTION
Closes #13 

Instead of choosing to fix on the `Attempting to switch worlds...` message, there is now a check globally to prevent any duplicate lines being matched on and sent to the backend. The only edge case to this I could find is if there are messages that are sent on the exact same tick which give the same timestamp in the chat logs. In this case, all messages at this time point will passing through the first global filter. The second line filter implemented is to then check the last message and if that matches the next line it is skipped.