### PR TITLE
App refresh reloads chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ This event tracker is an alt1 toolkit app for the Deep Sea Fishing Hub in RuneSc
 
 ## How to use
 
-As long as the alt1 app is open (can be minimized) and the game client is in focus, events from Misty will be captured and relayed to the [Deep Sea Fishing](https://discord.gg/whirlpooldnd) Discord.
+As long as the alt1 app is open (can be minimized), events from Misty will be captured and relayed to the [Deep Sea Fishing](https://discord.gg/whirlpooldnd) Discord.
 
 ## Requirements
 
 - **Game Messages** must be set to either Filtered or ON.
-- The game window must be in focus to capture the chatbox.
+- Please make sure the chatbox is clear of anything like buff bars overlapping.pp
 
 ## Installation
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -69,6 +69,8 @@ async function readChatFromImage(img: a1lib.ImgRefBind): Promise<void> {
 
     let combinedText = ""
     let recentTimestamp: null | string = null;
+    lastTimestamp = new Date(sessionStorage.getItem("lastTimestamp"))
+    lastMessage = sessionStorage.getItem("lastMessage")
     if (lines?.length) {
         // Remove blank lines
         if (lines.some(line => line.text === "")) lines = lines.filter(line => line.text !== "")
@@ -80,6 +82,7 @@ async function readChatFromImage(img: a1lib.ImgRefBind): Promise<void> {
         for (const line of lines) {
             if (line.text === lastMessage) continue
             lastMessage = line.text
+            sessionStorage.setItem("lastMessage", lastMessage)
             console.log(line)
             
             const allTextFromLine = line.text
@@ -87,7 +90,8 @@ async function readChatFromImage(img: a1lib.ImgRefBind): Promise<void> {
             
             if (hasTimestamps && line.fragments.length > 1) recentTimestamp = line.fragments[1].text
             lastTimestamp = new Date(`${new Date().toLocaleDateString()} ` + recentTimestamp) ?? new Date()
-
+            sessionStorage.setItem("lastTimestamp", String(lastTimestamp))
+            
             // Check if the text contains any keywords from the 'events' object
             const [partialMatch, matchingEvent] = getMatchingEvent(combinedText, events);
 


### PR DESCRIPTION
Fixes #17. Session storage does not reload on refreshing the app, only when re-opening it which should be fine as that would only really be done when someone closes the client. All text that has already been seen by the chatbox reader now does not get re-processed.