### PR TITLE
Add more text matching for event capture

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -206,37 +206,30 @@ async function readChatFromImage(img: a1lib.ImgRefBind): Promise<void> {
 
 // Helper function to check if the line contains a keyword from the events object
 function getMatchingEvent(lineText: string, events: Events): [boolean, EventKeys | null] {
-    // Define the regex pattern to match the line format
-    const regex = /^(?:\[\d{2}:\d{2}:\d{2}\]\s*)?Misty: .+$/;
-    const timeRegex = /\[\d{2}:\d{2}:\d{2}\]/;
+    // Define the regex pattern to match the time format and remove it if present
+    const timeRegex = /^\[\d{2}:\d{2}:\d{2}\]\s*/;
+    lineText = lineText.replace(timeRegex, "");
 
-    // Chop '[hh:mm:ss] '
-    if (timeRegex.test(lineText)) lineText = lineText.slice(11)
+    // Define allowed prefixes and remove them if present
+    const prefixes = ["Misty: ", "Fisherman: ", "Guys: "];
+    const matchingPrefix = prefixes.find(prefix => lineText.startsWith(prefix));
+    if (matchingPrefix) lineText = lineText.slice(matchingPrefix.length);
 
-    // Check if the lineText matches the regex or is a testing event
-    if (!regex.test(lineText) && !events["Testing"].some(phrase => phrase.includes(lineText))) {
-        return [false, null]; // Return null if the format does not match
-    }
+    // Accepted: Misty: something -> something \\ Match "something" in the event values
+    // Declined: FooBar: something -> FooBar: something \\ Match "FooBar: something" in the event values
 
-    // Chop 'Misty: '
-    if (lineText.startsWith("Misty: ")) lineText = lineText.slice(7)
-
-    // Loop through the events object
+    // Check if the lineText matches a phrase in any event
     for (const [eventKey, phrases] of Object.entries(events)) {
-        for (const phrase of phrases) {
-            // Check if the lineText equals any of the phrases
-            if (lineText === phrase) {
-                return [false, eventKey as EventKeys]; // Return the event key if a phrase matches
-            }
+        const exactMatch = phrases.find(phrase => lineText === phrase);
+        if (exactMatch) return [false, eventKey as EventKeys];
 
-            if (phrase.includes(lineText)) {
-                return [true, eventKey as EventKeys];
-            }
-        }
+        const partialMatch = phrases.find(phrase => phrase.includes(lineText));
+        if (partialMatch) return [true, eventKey as EventKeys];
     }
-    
-    return [false, null]; // Return null if no match is found
+
+    return [false, null]; // No match found
 }
+
 
 // Function to start capturing
 function startCapturing(): void {

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,6 +19,7 @@ chatbox.readargs.colors.push(
     a1lib.mixColor(...[255, 100, 0]),  // dark orange text
     a1lib.mixColor(...[255, 136, 0]),  // dsf merch text
     a1lib.mixColor(...[0, 166, 82]),  // misty text
+    a1lib.mixColor(...[50, 120, 190])  // fisherman
 );
 
 const imgs = webpackImages({

--- a/src/events.ts
+++ b/src/events.ts
@@ -8,13 +8,17 @@ export type Events = {
     [key in EventKeys]: string[];
 }
 
+// Gold text for event arrival is at the start of each value array
+// Fisherman text is at the end of events, if any
 export const events: Events = {
     "Travelling merchant": [
+        "The travelling merchant has arrived at the hub!",
         "I wonder what they've got for sale today?",
         "I've seen them sell some really sweet items before.",
         "They don't come around these parts too often, so make sure you check them out!"
     ],
     "Jellyfish": [
+        "A giant jellyfish has appeared!",
         "Jellyfish invasion inbound, get ready!", // Start
         "Another wave of jellyifsh just hopped onto the deck, get rid of them!", // Second round
         "Get them off the deck!", // Randomly
@@ -24,6 +28,7 @@ export const events: Events = {
         "They're messing up the deck, get rid of 'em!", // Randomly
     ],
     "Arkaneo": [
+        "The sailfish, Arkaneo, has appeared!",
         "I've heard stories of an angler named Tavia who managed to take a chunk out of him once.",
         "Look at how fast he is!",
         "It's Arkaneo!",
@@ -31,6 +36,7 @@ export const events: Events = {
         "No one has ever been able to catch this one.",
     ],
     "Sea Monster": [
+        "A sea monster has appeared!",
         "Ahh! The sea monster is back, get some rotten food from those barrels!", // Rotten fish
         "Oh no, it's hungry! Start throwing any raw food you've got at it",  // Raw fish
         "Come on, throw him some fish!",  // Randomly
@@ -42,6 +48,7 @@ export const events: Events = {
         "Throw him some fish!",  // Randomly
     ],
     "Treasure Turtle": [
+        "A treasure turtle has appeared at the hub!",
         "Check him out, don't miss your chance!",
         "I bet that chest is full of treasure.",
         "Lovely, lovely treasure...",
@@ -49,19 +56,26 @@ export const events: Events = {
         "These treasure turtles are awfully rare I'll have you know.",
     ],
     "Whale": [
+        "A whale has appeared at the hub!",
         "Captain, there be whales here!",
         "Don't fall in. You wouldn't want to get swallowed by that one!",
         "His mouth is full of fish, cast your lines!",
         "That's one giant whale!",
+        // Fisherman
+        "Get him to spit me out!",
+        "Ughhhhh! HELP!",
+        "Ugh! Give me a hand, he's swallowed me whole!",
+        "AHHHHHHHHHH! It's REALLY wet in here!"
     ],
     "Whirlpool": [
+        "A whirlpool has appeared at the hub!",
         "Don't fall in. You don't want to get sucked in by that!",
         "If you throw coins in and the whirlpool glows, that's when you know we're in for a treat!",
         "Sometimes we're rewarded for being generous, when throwing coins into the water.",
         "That's one big whirlpool!",
         "I nearly fell in before, that was scary..."
     ],
-    "Testing": ["Guys: 1", "Guys: Test", "Guys: Testing @@@@@ 123456789 abcdefghijklmnopqrstuvwxyz 123"],
+    "Testing": ["1", "Test", "Testing @@@@@ 123456789 abcdefghijklmnopqrstuvwxyz 123"],
 }
 
 const ONE_MINUTE = 60


### PR DESCRIPTION
Closes #23. All text in orange/gold related to the start of an event has been included as Misty sometimes is delayed. Additional text matching on the Whale event using the Fisherman text.