### PR TITLE
Prev chat fix

### DIFF
--- a/src/scripts/capture.ts
+++ b/src/scripts/capture.ts
@@ -40,6 +40,7 @@ let hasTimestamps: boolean;
 let lastTimestamp: Date;
 let lastMessage: string;
 let currentWorld: string | null = null;
+let maxBasey: number = 0
 
 let worldHopMessage = false;
 let mainboxRect = false;
@@ -334,6 +335,16 @@ async function readChatFromImage(img: a1lib.ImgRefBind): Promise<void> {
         lines = [];
         const futureTime = new Date(Number(new Date(`${new Date().toLocaleDateString()} ${lastGameTimestamp}`)) + 5000);
         sessionStorage.setItem("lastTimestamp", String(futureTime));
+    }
+
+    // Check before as a new line may not have timestamps but previous ones will
+    // Address a random edge case where the OCR reader reads a partial previous line
+    // which might match to an event
+    if (hasTimestamps) {
+        // If a lines basey is > 100 pixels out, then it is too far from the bottom
+        // of the chatbox (where new lines are read) so is probably a misread
+        // Allow 100 pixel distance for multiline text
+        lines = lines.filter((line) => line.basey > maxBasey - 100);
     }
 
     // Checks on every image captured whether there are timestamps in chat

--- a/src/scripts/capture.ts
+++ b/src/scripts/capture.ts
@@ -377,8 +377,11 @@ async function readChatFromImage(img: a1lib.ImgRefBind): Promise<void> {
                     line.fragments[1]?.text === undefined,
             );
         }
+        // Filter out the lines which just have a timestamp and optional space
+        lines = lines.filter((line) => !/^\[\d{2}:\d{2}:\d{2}\]\s*\S\W?$/.test(line.text))
 
         for (const line of lines) {
+            line.basey > maxBasey ? maxBasey = line.basey : maxBasey = maxBasey
             if (line.text === lastMessage) continue;
             const { updatedTimestamp, updatedLastMessage } = processLine(line, hasTimestamps);
 

--- a/src/scripts/merchantStock.ts
+++ b/src/scripts/merchantStock.ts
@@ -186,7 +186,6 @@ export function renderStockTable(): void {
             const item = stock[slot];
             if (item) {
                 const img = document.createElement("img");
-                console.log(item, getImagePath(item));
                 img.src = getImagePath(item);
                 img.alt = item;
                 img.title = item;

--- a/src/scripts/ws.ts
+++ b/src/scripts/ws.ts
@@ -34,7 +34,7 @@ const prepareLog = (args: unknown[]): string => {
     return args.map((arg) => (typeof arg === "object" ? JSON.stringify(arg) : String(arg))).join(" ");
 };
 
-async function refreshToken(): Promise<string | null> {
+export async function refreshToken(): Promise<string | null> {
     const refreshToken = localStorage.getItem("refreshToken");
 
     if (!refreshToken) {


### PR DESCRIPTION
Fixes issue with global delete not sending (as token was expired) and OCR detecting chatline which was further up the chatbox. Not sure why it was able to trigger the OCR except that it didn't have a timestamp so wasn't filtered by the timestamp check. This now checks if the line is further than 100 pixels from the "normal" position of a new line (at the bottom of the chatbox).