### PR TITLE
Check world still active with Misty

### DIFF
--- a/src/scripts/capture.ts
+++ b/src/scripts/capture.ts
@@ -179,6 +179,7 @@ export async function reportEvent(
         token: token,
         source: "alt1",
         profileEventKey,
+        mistyUpdate: false,
         ...overrides,
     };
 

--- a/src/scripts/eventHistory.ts
+++ b/src/scripts/eventHistory.ts
@@ -400,13 +400,15 @@ export function updateEventTimers(): void {
             if (!alreadyExpired) {
                 expiredEvents.push(event);
                 moveExpiredEventBelowActiveEvents(event);
-                console.log(`Adding world ${event.world} to Misty tab.`);
-                updateWorld({
-                    world: Number(event.world),
-                    status: "Inactive",
-                    last_update_timestamp: Date.now(),
-                    inactive_time: 0,
-                });
+                if (!event.mistyUpdate) {
+                    console.log(`Adding world ${event.world} to Misty tab.`);
+                    updateWorld({
+                        world: Number(event.world),
+                        status: "Inactive",
+                        last_update_timestamp: Date.now(),
+                        inactive_time: 0,
+                    });
+                }
             }
         }
     });
@@ -848,6 +850,7 @@ function editEvent(event: EventRecord): void {
             token: token,
             source: event.source,
             profileEventKey: event.profileEventKey,
+            mistyUpdate: false,
         };
 
         rowMap.set(event.id, row);

--- a/src/scripts/events.ts
+++ b/src/scripts/events.ts
@@ -133,4 +133,5 @@ export interface EventRecord {
     token: string | null;
     source: "alt1" | "discord";
     profileEventKey: string;
+    mistyUpdate: boolean;
 }

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -352,6 +352,7 @@ if (testEventButton && DEBUG) {
                 token: token,
                 source: "alt1",
                 profileEventKey: "alt1First.otherCount",
+                mistyUpdate: false,
             };
             localStorage.setItem("eventHistory", JSON.stringify([addTestEvent]));
         }
@@ -377,6 +378,7 @@ if (testEventButton && DEBUG) {
             token: token,
             source: "alt1",
             profileEventKey: "alt1First.otherCount",
+            mistyUpdate: false,
         };
         console.log("Emitting event_data", testEvent);
         wsClient.send(testEvent);


### PR DESCRIPTION
In the event where a world is still active in the Scouts tab (Discord call) but when checking with Misty, the event has ended - send an update to end the active event.