### PR TITLE
Removes non-alphanumeric characters from rsn when parsing

### DIFF
--- a/alt1/scripts/capture.ts
+++ b/alt1/scripts/capture.ts
@@ -293,8 +293,9 @@ async function readChatFromImage(img: a1lib.ImgRefBind): Promise<void> {
                 rsnRect.height,
             );
         }
-        const valkTitle = "of the Valkyrie";
-        if (data.text.includes("of the Valkyrie")) data.text.replace(valkTitle, "");
+        const valkTitle = " of the Valkyrie";
+        if (data.text.includes(valkTitle)) data.text = data.text.replace(valkTitle, "");
+        if (["!", ","].some((char) => data.text.includes(char))) data.text = data.text.replace(/[!,]/g, "");
 
         if (data.text !== "") {
             alt1.overLayRect(


### PR DESCRIPTION
In the server logs, rsn's are coming up to include `!` and `,` which are invalid. Could all more of them to the list but these two are the most common. This also adds the initial space to the `valkTitle` in the event that the user has that title displayed.