### PR TITLE
Add auth to patching profiles

### DIFF
--- a/alt1/scripts/capture.ts
+++ b/alt1/scripts/capture.ts
@@ -125,10 +125,10 @@ async function addEventCount(matchingEvent: EventKeys, worldNumber: string, isFi
             headers: {
                 "Content-Type": "application/json",
                 Origin: ORIGIN,
+                Authorization: `Bearer ${token}`,
             },
             key: isFirstEvent ? "alt1First" : "alt1",
             event: matchingEvent,
-            world: worldNumber,
         });
 
         if (addCountResponse.status === 200) {


### PR DESCRIPTION
Realised that this endpoint should probably be protected. Also removes `worldNumber` as this wasn't used on the backend.