### PR TITLE
Adds notifications for tooltip and toolbar

### DIFF
--- a/alt1/index.html
+++ b/alt1/index.html
@@ -115,8 +115,19 @@
                     </select>
                 </div>
                 <div class="form__group">
+                    <label for="notificationModes" title="Select multiple options">
+                        Notifications (Multi-Select)
+                        <button id="infoButtonNotificationMode" class="info-button" title="Click for info" type="button">ℹ️</button>
+                    </label>
+                    <select id="notificationModes" multiple size="5">
+                        <option value="tooltip">Tooltip</option>
+                        <option value="toolbar">Toolbar</option>
+                    </select>
+                    <a id="resetNotificationModes" style="display: block; cursor: pointer; margin-top: .5rem;">Reset notification modes</a>
+                </div>
+                <div class="form__group">
                     <label for="darkMode">Enable Dark Mode</label>
-                    <label class="theme-switch">
+                    <label class="switch">
                         <input type="checkbox" id="darkMode" />
                         <span class="slider"></span>
                     </label>
@@ -311,6 +322,25 @@
                     </li>
                 </ul>
             </div>
+        </div>
+        <div id="infoModalNotificationMode" class="modal">
+            <div class="modal-content">
+                <span class="close" title="Close">&times;</span>
+                <h2>Notification Modes</h2>
+                <p>This setting controls <strong>how</strong> notifications are delivered for tracked events. You can select one or multiple options below:</p>
+                <ul>
+                    <li><strong>Tooltip</strong> – Shows a short message near your cursor for a few seconds.</li>
+                    <li><strong>Toolbar</strong> – Displays a message in your RuneScape title bar for 2 minutes.</li>
+                </ul>
+                <p>
+                    You can select multiple modes using <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> or <kbd>Shift</kbd> when clicking.
+                    To clear your selections, use the <strong>Reset notification modes</strong> link below the selector.
+                </p>
+                <p>
+                    If no favorite events are set, <strong>all events</strong> will trigger notifications.
+                    Otherwise, only <strong>favorited events</strong> will.
+                </p>
+                <p><em>Note: Notifications will only be sent if the application is running inside Alt1.</em></p>
         </div>
         <!--  Modal for a confirmation -->
         <div id="confirmModal" class="modal">

--- a/alt1/index.html
+++ b/alt1/index.html
@@ -119,7 +119,7 @@
                         Notifications (Multi-Select)
                         <button id="infoButtonNotificationMode" class="info-button" title="Click for info" type="button">ℹ️</button>
                     </label>
-                    <select id="notificationModes" multiple size="5">
+                    <select id="notificationModes" multiple size="2">
                         <option value="tooltip">Tooltip</option>
                         <option value="toolbar">Toolbar</option>
                     </select>
@@ -278,6 +278,9 @@
                 <h2>Event History Information</h2>
                 <p>The <strong>Hide Expired</strong> checkbox hides any Expired events.</p>
                 <p>The <strong>Misty Timers</strong> checkbox will change the Time Left column to Misty Timer. If editing the event with this checked, you should input the time that Misty provides.</p>
+                <p>
+                    The <strong>Toggle notifications today</strong> checkbox will <strong>suppress notifications</strong> until 00:00 GMT, after which it resets automatically.
+                </p>
                 <p>The <strong>Clear All</strong> button will remove all events.</p>
                 <h3>Button Icons:</h3>
                 <ul>
@@ -331,22 +334,16 @@
             <div class="modal-content">
                 <span class="close" title="Close">&times;</span>
                 <h2>Notification Modes</h2>
-                <p>This setting controls <strong>how</strong> notifications are delivered for tracked events. You can select one or multiple options below:</p>
+                <p>Select one or more of the following:</p>
                 <ul>
                     <li><strong>Tooltip</strong> – Shows a short message near your cursor for a few seconds.</li>
                     <li><strong>Toolbar</strong> – Displays a message in your RuneScape toolbar until the time remaining expires or a new call is made.</li>
                 </ul>
                 <p>
-                    You can select multiple modes using <kbd>Ctrl</kbd> or <kbd>Shift</kbd> when clicking.
-                    To clear your selections, use the <strong>Reset notification modes</strong> link below the selector.
+                    Select multiple modes with <kbd>Ctrl</kbd> or <kbd>Shift</kbd>. To clear selections, click the <strong>Reset notification modes</strong> link.
                 </p>
                 <p>
-                    If no favorite events are set, <strong>all events</strong> will trigger notifications.
-                    Otherwise, only <strong>favorited events</strong> will.
-                </p>
-                <p>
-                    Additionally, you can use the <strong>“Toggle notifications today”</strong> checkbox located in the <em>Event History</em> sub-tab of the <em>Scouts</em> tab.
-                    When enabled, it will <strong>suppress notifications</strong> until 00:00 GMT, after which it resets automatically.
+                    <strong>All events</strong> will trigger notifications unless <strong>favorited events</strong> are set.
                 </p>
                 <p><em>Note: Notifications will only be sent if the application is running inside Alt1.</em></p>
             </div>

--- a/alt1/index.html
+++ b/alt1/index.html
@@ -175,6 +175,10 @@
                                 <input type="checkbox" id="toggleMistyTimer" />
                                 Misty Timers
                                 </label>
+                                <label>
+                                    <input type="checkbox" id="toggleNotificationsToday" />
+                                    Toggle notifications today
+                                </label>
                                 <label id="debugContainer">
                                 <select id="testEventSelect"></select>
                                 <button id="testWS">WS Event</button>
@@ -330,15 +334,19 @@
                 <p>This setting controls <strong>how</strong> notifications are delivered for tracked events. You can select one or multiple options below:</p>
                 <ul>
                     <li><strong>Tooltip</strong> – Shows a short message near your cursor for a few seconds.</li>
-                    <li><strong>Toolbar</strong> – Displays a message in your RuneScape title bar for 2 minutes.</li>
+                    <li><strong>Toolbar</strong> – Displays a message in your RuneScape toolbar until the time remaining expires or a new call is made.</li>
                 </ul>
                 <p>
-                    You can select multiple modes using <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> or <kbd>Shift</kbd> when clicking.
+                    You can select multiple modes using <kbd>Ctrl</kbd> or <kbd>Shift</kbd> when clicking.
                     To clear your selections, use the <strong>Reset notification modes</strong> link below the selector.
                 </p>
                 <p>
                     If no favorite events are set, <strong>all events</strong> will trigger notifications.
                     Otherwise, only <strong>favorited events</strong> will.
+                </p>
+                <p>
+                    Additionally, you can use the <strong>“Toggle notifications today”</strong> checkbox located in the <em>Event History</em> sub-tab of the <em>Scouts</em> tab.
+                    When enabled, it will <strong>suppress notifications</strong> until 00:00 GMT, after which it resets automatically.
                 </p>
                 <p><em>Note: Notifications will only be sent if the application is running inside Alt1.</em></p>
         </div>

--- a/alt1/index.html
+++ b/alt1/index.html
@@ -279,7 +279,7 @@
                 <p>The <strong>Hide Expired</strong> checkbox hides any Expired events.</p>
                 <p>The <strong>Misty Timers</strong> checkbox will change the Time Left column to Misty Timer. If editing the event with this checked, you should input the time that Misty provides.</p>
                 <p>
-                    The <strong>Toggle notifications today</strong> checkbox will <strong>suppress notifications</strong> until 00:00 GMT, after which it resets automatically.
+                    The <strong>Toggle notifications today</strong> checkbox will <strong>suppress notifications</strong> until 00:00 UTC, after which it resets automatically.
                 </p>
                 <p>The <strong>Clear All</strong> button will remove all events.</p>
                 <h3>Button Icons:</h3>

--- a/alt1/index.html
+++ b/alt1/index.html
@@ -349,6 +349,7 @@
                     When enabled, it will <strong>suppress notifications</strong> until 00:00 GMT, after which it resets automatically.
                 </p>
                 <p><em>Note: Notifications will only be sent if the application is running inside Alt1.</em></p>
+            </div>
         </div>
         <!--  Modal for a confirmation -->
         <div id="confirmModal" class="modal">

--- a/alt1/scripts/app.ts
+++ b/alt1/scripts/app.ts
@@ -37,3 +37,7 @@ a1lib.on("rsfocus", () => {
     startCapturing();
     // Optionally restore main content if needed
 });
+
+window.addEventListener("unload", () => {
+    alt1.setTitleBarText("");
+});

--- a/alt1/scripts/capture.ts
+++ b/alt1/scripts/capture.ts
@@ -89,8 +89,8 @@ export function initCapture(): void {
     previousMainContent = document.querySelector("#mainTab h2")!.innerHTML;
     loadEventHistory();
     renderMistyTimers();
+
     const notificationModes = JSON.parse(localStorage.getItem("notificationModes"));
-    console.log("notificationModes", notificationModes);
     if (notificationModes && notificationModes.includes("toolbar")) {
         alt1.setTitleBarText("Listening for DSF events...");
     } else {

--- a/alt1/scripts/capture.ts
+++ b/alt1/scripts/capture.ts
@@ -90,7 +90,7 @@ export function initCapture(): void {
     loadEventHistory();
     renderMistyTimers();
 
-    const notificationModes = JSON.parse(localStorage.getItem("notificationModes"));
+    const notificationModes = JSON.parse(localStorage.getItem("notificationModes") ?? "[]");
     if (notificationModes && notificationModes.includes("toolbar")) {
         alt1.setTitleBarText("Listening for DSF events...");
     } else {

--- a/alt1/scripts/capture.ts
+++ b/alt1/scripts/capture.ts
@@ -91,10 +91,10 @@ export function initCapture(): void {
     renderMistyTimers();
     const notificationModes = JSON.parse(localStorage.getItem("notificationModes"));
     console.log("notificationModes", notificationModes);
-    if (!notificationModes || notificationModes.length === 0) {
-        alt1.setTitleBarText("");
-    } else {
+    if (notificationModes && notificationModes.includes("toolbar")) {
         alt1.setTitleBarText("Listening for DSF events...");
+    } else {
+        alt1.setTitleBarText("");
     }
 
     const eventHistoryTab = document.getElementById("eventHistoryTab");

--- a/alt1/scripts/capture.ts
+++ b/alt1/scripts/capture.ts
@@ -13,6 +13,7 @@ import Fuse from "fuse.js";
 import { decodeJWT } from "./permissions";
 import { renderMistyTimers, startMistyimerRefresh } from "./mistyTimers";
 import { startCapturingMisty } from "./mistyDialog";
+import { setDefaultTitleBar } from "./notifications";
 
 /**
  * ChatBoxReader & color definitions
@@ -92,7 +93,7 @@ export function initCapture(): void {
 
     const notificationModes = JSON.parse(localStorage.getItem("notificationModes") ?? "[]");
     if (notificationModes && notificationModes.includes("toolbar")) {
-        alt1.setTitleBarText("Listening for DSF events...");
+        setDefaultTitleBar();
     } else {
         alt1.setTitleBarText("");
     }

--- a/alt1/scripts/capture.ts
+++ b/alt1/scripts/capture.ts
@@ -89,6 +89,13 @@ export function initCapture(): void {
     previousMainContent = document.querySelector("#mainTab h2")!.innerHTML;
     loadEventHistory();
     renderMistyTimers();
+    const notificationModes = JSON.parse(localStorage.getItem("notificationModes"));
+    console.log("notificationModes", notificationModes);
+    if (!notificationModes || notificationModes.length === 0) {
+        alt1.setTitleBarText("");
+    } else {
+        alt1.setTitleBarText("Listening for DSF events...");
+    }
 
     const eventHistoryTab = document.getElementById("eventHistoryTab");
     if (eventHistoryTab?.classList.contains("sub-tab__content--active")) {

--- a/alt1/scripts/eventHistory.ts
+++ b/alt1/scripts/eventHistory.ts
@@ -707,8 +707,7 @@ export function getRemainingTime(event: EventRecord): number {
 }
 
 function checkActive(event: EventRecord): boolean {
-    const remaining = getRemainingTime(event);
-    return remaining > 0;
+    return getRemainingTime(event) > 0;
 }
 
 function editEvent(event: EventRecord): void {

--- a/alt1/scripts/eventHistory.ts
+++ b/alt1/scripts/eventHistory.ts
@@ -528,9 +528,7 @@ function appendEventRow(event: EventRecord, highlight: boolean = false, pin: boo
         row.classList.add("favourite-event");
     }
 
-    const now = Date.now();
-    const elapsed = (now - event.timestamp) / 1000;
-    const remaining = event.duration - elapsed;
+    const remaining = getRemainingTime(event);
 
     const buttonsTd = document.createElement("td");
     const buttonContainer = document.createElement("div");
@@ -702,10 +700,14 @@ export function removeEvent(event: EventRecord): void {
     rowMap.delete(event.id);
 }
 
-function checkActive(event: EventRecord): boolean {
+export function getRemainingTime(event: EventRecord): number {
     const now = Date.now();
     const elapsed = (now - event.timestamp) / 1000;
-    const remaining = event.duration - elapsed;
+    return event.duration - elapsed;
+}
+
+function checkActive(event: EventRecord): boolean {
+    const remaining = getRemainingTime(event);
     return remaining > 0;
 }
 
@@ -881,12 +883,12 @@ function formatTimeLeft(event: EventRecord): string {
     }
 }
 
-function formatTimeLeftValue(seconds: number): string {
+export function formatTimeLeftValue(seconds: number, showSeconds: boolean = true): string {
     const mistyToggle = localStorage.getItem("toggleMistyTimer") === "true";
     if (seconds <= 0 && !mistyToggle) return "Expired";
     const mins = Math.floor(seconds / 60);
     const secs = Math.floor(seconds % 60);
-    return `${mins}m ${secs}s`;
+    return showSeconds ? `${mins}m ${secs}s` : `${mins}m`;
 }
 
 function parseDuration(durationStr: string): number {

--- a/alt1/scripts/notifications.ts
+++ b/alt1/scripts/notifications.ts
@@ -92,8 +92,11 @@ export function showTitleBarText(event: EventRecord, message: string, duration: 
             return;
         }
 
-        const friendlyRemaining = formatTimeLeftValue(Math.max(remaining, 0), false);
-        alt1.setTitleBarText(`${message} for ~${friendlyRemaining}`);
+        const friendlyRemaining =
+            remaining < 60
+                ? "under a minute"
+                : formatTimeLeftValue(Math.max(remaining, 0), false);
+        alt1.setTitleBarText(`${message} for ${friendlyRemaining}`);
     };
 
     // Immediately update once

--- a/alt1/scripts/notifications.ts
+++ b/alt1/scripts/notifications.ts
@@ -41,7 +41,7 @@ export function notifyEvent(event: EventRecord): void {
         return;
     }
 
-    const notificationModes = JSON.parse(localStorage.getItem("notificationModes")) as NotificationModes[] | null;
+    const notificationModes = JSON.parse(localStorage.getItem("notificationModes") ?? "[]");
     const favoriteEventsRaw = localStorage.getItem("favoriteEvents");
 
     // if favorite events are set, only show the favorites, otherwise, show all

--- a/alt1/scripts/notifications.ts
+++ b/alt1/scripts/notifications.ts
@@ -1,5 +1,5 @@
 import { EventRecord } from "./events";
-import {formatTimeLeftValue, getRemainingTime} from './eventHistory';
+import { formatTimeLeftValue, getRemainingTime } from "./eventHistory";
 
 export type NotificationModes = "none" | "tooltip" | "toolbar" | "all";
 
@@ -31,7 +31,7 @@ export function showToast(message: string, type: "error" | "success" = "success"
 }
 
 export function notifyEvent(event: EventRecord): void {
-    console.log('notified', event);
+    console.log("notified", event);
     // early return if we aren't in alt1
     if (!window.alt1) {
         return;
@@ -45,8 +45,8 @@ export function notifyEvent(event: EventRecord): void {
     const notificationModes = localStorage.getItem("notificationModes") as NotificationModes[] | null;
     const favoriteEventsRaw = localStorage.getItem("favoriteEvents");
 
-    console.log('mode', notificationModes);
-    console.log('favorites', favoriteEventsRaw);
+    console.log("mode", notificationModes);
+    console.log("favorites", favoriteEventsRaw);
 
     // if favorite events are set, only show the favorites, otherwise, show all
     if (favoriteEventsRaw) {
@@ -83,13 +83,12 @@ export function showTooltip(message: string, time: number = 5000): void {
     }, time);
 }
 
-
 export function showTitleBarText(event: EventRecord, message: string, duration: number = 120000): void {
     const updateTitle = () => {
         const remaining = getRemainingTime(event);
 
         if (remaining <= 0) {
-            alt1.setTitleBarText('');
+            alt1.setTitleBarText("");
             if (titlebarInterval) {
                 clearInterval(titlebarInterval);
             }
@@ -98,9 +97,7 @@ export function showTitleBarText(event: EventRecord, message: string, duration: 
         }
 
         const friendlyRemaining =
-            remaining < 60
-                ? "under a minute"
-                : formatTimeLeftValue(Math.max(remaining, 0), false);
+            remaining < 60 ? "under a minute" : formatTimeLeftValue(Math.max(remaining, 0), false);
         alt1.setTitleBarText(`${message} for ${friendlyRemaining}`);
     };
 
@@ -120,7 +117,7 @@ export function showTitleBarText(event: EventRecord, message: string, duration: 
 
     // Final clear (in case interval missed the exact end)
     titlebarTimeout = setTimeout(() => {
-        alt1.setTitleBarText('');
+        alt1.setTitleBarText("");
         if (titlebarInterval) {
             clearInterval(titlebarInterval);
         }

--- a/alt1/scripts/notifications.ts
+++ b/alt1/scripts/notifications.ts
@@ -127,7 +127,7 @@ export function showTitleBarText(event: EventRecord, message: string, duration: 
 
     // Final fallback cleanup in case interval missed the end
     titlebarTimeout = setTimeout(() => {
-        alt1.setTitleBarText("");
+        alt1.setTitleBarText("Listening for DSF events...");
         if (titlebarInterval) {
             clearInterval(titlebarInterval);
         }

--- a/alt1/scripts/notifications.ts
+++ b/alt1/scripts/notifications.ts
@@ -122,8 +122,8 @@ export function showTitleBarText(event: EventRecord, message: string, duration: 
         clearTimeout(titlebarTimeout);
     }
 
-    // Start interval to update every minute
-    titlebarInterval = setInterval(updateTitle, 60000);
+    // Start interval to update every half minute
+    titlebarInterval = setInterval(updateTitle, 30000);
 
     // Final fallback cleanup in case interval missed the end
     titlebarTimeout = setTimeout(() => {

--- a/alt1/scripts/notifications.ts
+++ b/alt1/scripts/notifications.ts
@@ -1,3 +1,12 @@
+import { EventRecord } from "./events";
+import {formatTimeLeftValue, getRemainingTime} from './eventHistory';
+
+export type NotificationModes = "none" | "tooltip" | "toolbar" | "all";
+
+let tooltipTimeout: ReturnType<typeof setTimeout> | null = null;
+let titlebarTimeout: ReturnType<typeof setTimeout> | null = null;
+let titlebarInterval: ReturnType<typeof setTimeout> | null = null;
+
 // Function to show toast notification using new BEM modifier for "show"
 export function showToast(message: string, type: "error" | "success" = "success"): void {
     const toast = document.createElement("div");
@@ -19,4 +28,95 @@ export function showToast(message: string, type: "error" | "success" = "success"
         toast.classList.remove("toast--show");
         setTimeout(() => toast.remove(), 500); // Remove from DOM
     }, 3000);
+}
+
+export function notifyEvent(event: EventRecord): void {
+    console.log('notified', event);
+    // early return if we aren't in alt1
+    if (!window.alt1) {
+        return;
+    }
+
+    const notificationModes = localStorage.getItem("notificationModes") as NotificationModes[] | null;
+    const favoriteEventsRaw = localStorage.getItem("favoriteEvents");
+
+    console.log('mode', notificationModes);
+    console.log('favorites', favoriteEventsRaw);
+
+    // if favorite events are set, only show the favorites, otherwise, show all
+    if (favoriteEventsRaw) {
+        const favoriteEvents: string[] = JSON.parse(favoriteEventsRaw);
+        if (favoriteEvents.length > 0 && !favoriteEvents.includes(event.event)) {
+            return;
+        }
+    }
+
+    if (!notificationModes || notificationModes.length === 0) {
+        return;
+    }
+
+    const message = `${event.event} on w${event.world}`;
+
+    if (notificationModes.includes("tooltip")) {
+        showTooltip(message);
+    }
+
+    if (notificationModes.includes("toolbar")) {
+        showTitleBarText(event, `${message}`, event.duration * 1000);
+    }
+}
+
+export function showTooltip(message: string, time: number = 5000): void {
+    alt1.setTooltip(message);
+
+    if (tooltipTimeout) {
+        clearTimeout(tooltipTimeout);
+    }
+
+    tooltipTimeout = setTimeout(() => {
+        alt1.clearTooltip();
+    }, time);
+}
+
+
+export function showTitleBarText(event: EventRecord, message: string, duration: number = 120000): void {
+    const updateTitle = () => {
+        const remaining = getRemainingTime(event);
+
+        if (remaining <= 0) {
+            alt1.setTitleBarText('');
+            if (titlebarInterval) {
+                clearInterval(titlebarInterval);
+            }
+            titlebarInterval = null;
+            return;
+        }
+
+        const friendlyRemaining = formatTimeLeftValue(Math.max(remaining, 0), false);
+        alt1.setTitleBarText(`${message} for ~${friendlyRemaining}`);
+    };
+
+    // Immediately update once
+    updateTitle();
+
+    // Clear any previous interval/timeout
+    if (titlebarInterval) {
+        clearInterval(titlebarInterval);
+    }
+    if (titlebarTimeout) {
+        clearTimeout(titlebarTimeout);
+    }
+
+    // Start interval to update every second
+    titlebarInterval = setInterval(updateTitle, 60000);
+
+    // Final clear (in case interval missed the exact end)
+    titlebarTimeout = setTimeout(() => {
+        alt1.setTitleBarText('');
+        if (titlebarInterval) {
+            clearInterval(titlebarInterval);
+        }
+        titlebarInterval = null;
+        titlebarTimeout = null;
+    }, duration);
 }

--- a/alt1/scripts/notifications.ts
+++ b/alt1/scripts/notifications.ts
@@ -31,7 +31,6 @@ export function showToast(message: string, type: "error" | "success" = "success"
 }
 
 export function notifyEvent(event: EventRecord): void {
-    console.log("notified", event);
     // early return if we aren't in alt1
     if (!window.alt1) {
         return;

--- a/alt1/scripts/notifications.ts
+++ b/alt1/scripts/notifications.ts
@@ -56,7 +56,7 @@ export function notifyEvent(event: EventRecord): void {
         return;
     }
 
-        if (
+    if (
         (event.type === "deleteEvent" || (event.type === "editEvent" && event.duration === 0)) &&
         event.id === recentEvent?.id
     ) {

--- a/alt1/scripts/notifications.ts
+++ b/alt1/scripts/notifications.ts
@@ -92,7 +92,7 @@ export function notifyEvent(event: EventRecord): void {
     }
 
     if (notificationModes.includes("toolbar")) {
-        showTitleBarText(event, message, event.duration * 1000);
+        showTitleBarText(event, message, getRemainingTime(event) * 1000);
     }
 }
 

--- a/alt1/scripts/notifications.ts
+++ b/alt1/scripts/notifications.ts
@@ -37,6 +37,11 @@ export function notifyEvent(event: EventRecord): void {
         return;
     }
 
+    const suppressToday = localStorage.getItem("toggleNotificationsToday") === "true";
+    if (suppressToday) {
+        return;
+    }
+
     const notificationModes = localStorage.getItem("notificationModes") as NotificationModes[] | null;
     const favoriteEventsRaw = localStorage.getItem("favoriteEvents");
 

--- a/alt1/scripts/notifications.ts
+++ b/alt1/scripts/notifications.ts
@@ -56,7 +56,10 @@ export function notifyEvent(event: EventRecord): void {
         return;
     }
 
-    if (event.type === "deleteEvent" && event.id === recentEvent?.id) {
+        if (
+        (event.type === "deleteEvent" || (event.type === "editEvent" && event.duration === 0)) &&
+        event.id === recentEvent?.id
+    ) {
         const historyRaw = localStorage.getItem("eventHistory");
 
         if (historyRaw) {

--- a/alt1/scripts/notifications.ts
+++ b/alt1/scripts/notifications.ts
@@ -1,9 +1,6 @@
 import { EventRecord } from "./events";
 import { formatTimeLeftValue, getRemainingTime } from "./eventHistory";
 
-export type NotificationModes = "none" | "tooltip" | "toolbar" | "all";
-
-let tooltipTimeout: ReturnType<typeof setTimeout> | null = null;
 let titlebarTimeout: ReturnType<typeof setTimeout> | null = null;
 let titlebarInterval: ReturnType<typeof setTimeout> | null = null;
 
@@ -38,6 +35,7 @@ export function notifyEvent(event: EventRecord): void {
 
     const suppressToday = localStorage.getItem("toggleNotificationsToday") === "true";
     if (suppressToday) {
+        alt1.setTitleBarText("");
         return;
     }
 
@@ -63,23 +61,17 @@ export function notifyEvent(event: EventRecord): void {
     }
 
     if (notificationModes.includes("toolbar")) {
-        showTitleBarText(event, `${message}`, event.duration * 1000);
+        showTitleBarText(event, message, event.duration * 1000);
     }
 }
 
-export function showTooltip(message: string, time: number = 5000): void {
+function showTooltip(message: string, durationMs: number = 5_000): void {
     alt1.setTooltip(message);
 
-    if (tooltipTimeout) {
-        clearTimeout(tooltipTimeout);
-    }
-
-    tooltipTimeout = setTimeout(() => {
-        alt1.clearTooltip();
-    }, time);
+    setTimeout(alt1.clearTooltip, durationMs);
 }
 
-export function showTitleBarText(event: EventRecord, message: string, duration: number = 120000): void {
+function showTitleBarText(event: EventRecord, message: string, durationMs: number = 120_000): void {
     const updateTitle = () => {
         const suppressToday = localStorage.getItem("toggleNotificationsToday") === "true";
 
@@ -106,8 +98,7 @@ export function showTitleBarText(event: EventRecord, message: string, duration: 
             return;
         }
 
-        const friendlyRemaining =
-            remaining < 60 ? "under a minute" : formatTimeLeftValue(Math.max(remaining, 0), false);
+        const friendlyRemaining = remaining < 60 ? "under 1m" : formatTimeLeftValue(Math.max(remaining, 0), false);
         alt1.setTitleBarText(`${message} for ${friendlyRemaining}`);
     };
 
@@ -123,7 +114,7 @@ export function showTitleBarText(event: EventRecord, message: string, duration: 
     }
 
     // Start interval to update every half minute
-    titlebarInterval = setInterval(updateTitle, 30000);
+    titlebarInterval = setInterval(updateTitle, 30_000);
 
     // Final fallback cleanup in case interval missed the end
     titlebarTimeout = setTimeout(() => {
@@ -133,5 +124,5 @@ export function showTitleBarText(event: EventRecord, message: string, duration: 
         }
         titlebarInterval = null;
         titlebarTimeout = null;
-    }, duration);
+    }, durationMs);
 }

--- a/alt1/scripts/ui.ts
+++ b/alt1/scripts/ui.ts
@@ -91,6 +91,16 @@ if (favoriteEventsModeSelect && savedFavMode) {
     favoriteEventsModeSelect.value = savedFavMode;
 }
 
+const notificationModesSelect = document.getElementById("notificationModes") as HTMLSelectElement | null;
+const notificationModes = localStorage.getItem("notificationModes");
+if (notificationModes && notificationModesSelect) {
+    const favorites: string[] = JSON.parse(notificationModes);
+    // Mark these options as selected
+    Array.from(notificationModesSelect.options).forEach((option) => {
+        option.selected = favorites.includes(option.value);
+    });
+}
+
 const darkModeSwitch = document.getElementById("darkMode") as HTMLInputElement | null;
 const darkMode = localStorage.getItem("darkMode");
 if (darkModeSwitch && darkMode) {
@@ -111,6 +121,20 @@ function setDarkMode(): void {
 }
 
 setDarkMode();
+
+// Handle reset notification modes
+const resetNotificationModes = document.getElementById("resetNotificationModes") as HTMLAnchorElement | null;
+resetNotificationModes?.addEventListener("click", (e) => {
+    if (notificationModesSelect) {
+        // Clear all selected options
+        Array.from(notificationModesSelect.options).forEach(option => {
+            option.selected = false;
+        });
+
+        // Update localStorage to reflect empty state
+        localStorage.setItem("notificationModes", JSON.stringify([]));
+    }
+});
 
 // Handle settings form submission and save to localStorage
 const settingsForm = document.getElementById("settingsForm") as HTMLFormElement | null;
@@ -133,6 +157,12 @@ settingsForm?.addEventListener("submit", (e) => {
 
     if (favoriteEventsModeSelect) {
         updateIfChanged("favoriteEventsMode", favoriteEventsModeSelect.value);
+    }
+
+    if (notificationModesSelect) {
+        const selectedValues = Array.from(notificationModesSelect.selectedOptions).map((opt) => opt.value);
+        console.log('selected modes', selectedValues)
+        updateIfChanged("notificationModes", JSON.stringify(selectedValues));
     }
 
     if (darkModeSwitch) {
@@ -435,6 +465,7 @@ window.addEventListener("DOMContentLoaded", () => {
             populateEventDropdown();
         }
     }
+
     const infoButtonEventHistory = document.getElementById("infoButtonEventHistory") as HTMLElement;
     const modalScouts = document.getElementById("infoModalScouts") as HTMLElement;
     const closeModalScouts = modalScouts.querySelector(".close") as Element;
@@ -474,6 +505,24 @@ window.addEventListener("DOMContentLoaded", () => {
     window.addEventListener("click", function (event) {
         if (event.target === modalMisty) {
             modalMisty.style.display = "none";
+        }
+    });
+
+    const infoButtonNotificationMode = document.getElementById("infoButtonNotificationMode") as HTMLElement;
+    const modalNotificationMode = document.getElementById("infoModalNotificationMode") as HTMLElement;
+    const closeModalNotificationMode = modalNotificationMode.querySelector(".close") as Element;
+
+    infoButtonNotificationMode.addEventListener("click", function () {
+        modalNotificationMode.style.display = "flex";
+    });
+
+    closeModalNotificationMode.addEventListener("click", function () {
+        modalNotificationMode.style.display = "none";
+    });
+
+    window.addEventListener("click", function (event) {
+        if (event.target === modalNotificationMode) {
+            modalNotificationMode.style.display = "none";
         }
     });
 

--- a/alt1/scripts/ui.ts
+++ b/alt1/scripts/ui.ts
@@ -342,7 +342,7 @@ if (toggleNotificationsToday) {
         toggleNotificationsToday.checked = storedState;
     }
 
-    // 🔁 If enabled, schedule the reset
+    // If enabled, schedule the reset
     if (toggleNotificationsToday.checked) {
         scheduleNotificationResetAtMidnightUTC();
     }
@@ -389,7 +389,7 @@ function scheduleNotificationResetAtMidnightUTC(): void {
             toggleNotificationsToday.checked = false;
         }
 
-        showToast("Daily notification toggle has reset");
+        showToast("Notification suppression has reset");
 
         midnightResetTimeoutId = null;
     }, msUntilMidnight);

--- a/alt1/scripts/ui.ts
+++ b/alt1/scripts/ui.ts
@@ -94,10 +94,10 @@ if (favoriteEventsModeSelect && savedFavMode) {
 const notificationModesSelect = document.getElementById("notificationModes") as HTMLSelectElement | null;
 const notificationModes = localStorage.getItem("notificationModes");
 if (notificationModes && notificationModesSelect) {
-    const favorites: string[] = JSON.parse(notificationModes);
+    const modes: string[] = JSON.parse(notificationModes);
     // Mark these options as selected
     Array.from(notificationModesSelect.options).forEach((option) => {
-        option.selected = favorites.includes(option.value);
+        option.selected = modes.includes(option.value);
     });
 }
 
@@ -161,8 +161,12 @@ settingsForm?.addEventListener("submit", (e) => {
 
     if (notificationModesSelect) {
         const selectedValues = Array.from(notificationModesSelect.selectedOptions).map((opt) => opt.value);
-        console.log("selected modes", selectedValues);
         updateIfChanged("notificationModes", JSON.stringify(selectedValues));
+        if (selectedValues && selectedValues.length > 0) {
+            alt1.setTitleBarText("Listening for DSF events...");
+        } else {
+            alt1.setTitleBarText("");
+        }
     }
 
     if (darkModeSwitch) {

--- a/alt1/scripts/ui.ts
+++ b/alt1/scripts/ui.ts
@@ -124,10 +124,10 @@ setDarkMode();
 
 // Handle reset notification modes
 const resetNotificationModes = document.getElementById("resetNotificationModes") as HTMLAnchorElement | null;
-resetNotificationModes?.addEventListener("click", (e) => {
+resetNotificationModes?.addEventListener("click", () => {
     if (notificationModesSelect) {
         // Clear all selected options
-        Array.from(notificationModesSelect.options).forEach(option => {
+        Array.from(notificationModesSelect.options).forEach((option) => {
             option.selected = false;
         });
 
@@ -161,7 +161,7 @@ settingsForm?.addEventListener("submit", (e) => {
 
     if (notificationModesSelect) {
         const selectedValues = Array.from(notificationModesSelect.selectedOptions).map((opt) => opt.value);
-        console.log('selected modes', selectedValues)
+        console.log("selected modes", selectedValues);
         updateIfChanged("notificationModes", JSON.stringify(selectedValues));
     }
 
@@ -375,7 +375,7 @@ function scheduleNotificationResetAtMidnightUTC(): void {
         now.getUTCDate(),
         now.getUTCHours(),
         now.getUTCMinutes(),
-        now.getUTCSeconds()
+        now.getUTCSeconds(),
     );
     const utcMidnight = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1, 0, 0, 0);
 

--- a/alt1/scripts/ui.ts
+++ b/alt1/scripts/ui.ts
@@ -162,7 +162,7 @@ settingsForm?.addEventListener("submit", (e) => {
     if (notificationModesSelect) {
         const selectedValues = Array.from(notificationModesSelect.selectedOptions).map((opt) => opt.value);
         updateIfChanged("notificationModes", JSON.stringify(selectedValues));
-        if (selectedValues && selectedValues.length > 0) {
+        if (selectedValues && selectedValues.includes("toolbar")) {
             alt1.setTitleBarText("Listening for DSF events...");
         } else {
             alt1.setTitleBarText("");

--- a/alt1/scripts/ws.ts
+++ b/alt1/scripts/ws.ts
@@ -7,6 +7,7 @@ import { decodeJWT, ExpiredTokenRecord } from "./permissions";
 import { updateProfileCounters, ProfileRecord, getEventCountData } from "./profile";
 import { WorldEventStatus, updateWorld } from "./mistyTimers";
 import { WorldRecord } from "./mistyDialog";
+import {notifyEvent} from './notifications';
 
 type ReceivedData = EventRecord | ProfileRecord | ExpiredTokenRecord | EventRecord[] | WorldEventStatus;
 
@@ -178,6 +179,7 @@ export class WebSocketClient {
         if (eventData.type === "addEvent") addNewEvent(eventData);
         if (eventData.type === "editEvent") updateEvent(eventData);
         if (eventData.type === "deleteEvent") removeEvent(eventData);
+        notifyEvent(eventData);
     }
 
     sendSync(lastEventTimestamp: number, lastEventId: UUIDTypes | undefined): void {

--- a/alt1/scripts/ws.ts
+++ b/alt1/scripts/ws.ts
@@ -176,10 +176,12 @@ export class WebSocketClient {
 
     processEvent(eventData: EventRecord): void {
         console.log("Parsed data: ", eventData);
-        if (eventData.type === "addEvent") addNewEvent(eventData);
+        if (eventData.type === "addEvent") {
+            addNewEvent(eventData);
+            notifyEvent(eventData);
+        }
         if (eventData.type === "editEvent") updateEvent(eventData);
         if (eventData.type === "deleteEvent") removeEvent(eventData);
-        notifyEvent(eventData);
     }
 
     sendSync(lastEventTimestamp: number, lastEventId: UUIDTypes | undefined): void {

--- a/alt1/scripts/ws.ts
+++ b/alt1/scripts/ws.ts
@@ -180,7 +180,10 @@ export class WebSocketClient {
             addNewEvent(eventData);
             notifyEvent(eventData);
         }
-        if (eventData.type === "editEvent") updateEvent(eventData);
+        if (eventData.type === "editEvent") {
+            updateEvent(eventData);
+            notifyEvent(eventData);
+        }
         if (eventData.type === "deleteEvent") removeEvent(eventData);
     }
 

--- a/alt1/scripts/ws.ts
+++ b/alt1/scripts/ws.ts
@@ -176,15 +176,10 @@ export class WebSocketClient {
 
     processEvent(eventData: EventRecord): void {
         console.log("Parsed data: ", eventData);
-        if (eventData.type === "addEvent") {
-            addNewEvent(eventData);
-            notifyEvent(eventData);
-        }
-        if (eventData.type === "editEvent") {
-            updateEvent(eventData);
-            notifyEvent(eventData);
-        }
+        if (eventData.type === "addEvent") addNewEvent(eventData);
+        if (eventData.type === "editEvent") updateEvent(eventData);
         if (eventData.type === "deleteEvent") removeEvent(eventData);
+        notifyEvent(eventData);
     }
 
     sendSync(lastEventTimestamp: number, lastEventId: UUIDTypes | undefined): void {

--- a/alt1/scripts/ws.ts
+++ b/alt1/scripts/ws.ts
@@ -7,7 +7,7 @@ import { decodeJWT, ExpiredTokenRecord } from "./permissions";
 import { updateProfileCounters, ProfileRecord, getEventCountData } from "./profile";
 import { WorldEventStatus, updateWorld } from "./mistyTimers";
 import { WorldRecord } from "./mistyDialog";
-import {notifyEvent} from './notifications';
+import { notifyEvent } from "./notifications";
 
 type ReceivedData = EventRecord | ProfileRecord | ExpiredTokenRecord | EventRecord[] | WorldEventStatus;
 

--- a/alt1/styles/style.css
+++ b/alt1/styles/style.css
@@ -709,11 +709,13 @@ small {
 ------------------------------------- */
 /* Info button style */
 .info-button {
-    background: none;
-    border: none;
+    background: linear-gradient(135deg, #0077cc, #005fa3);
+    border-radius: 5px;
     cursor: pointer;
+    color: white;
     font-size: 1.2em;
     padding: 1px 3px !important;
+    border: none;
 }
 
 body.dark-mode .info-button, body.dark-mode .reset-button {

--- a/alt1/styles/style.css
+++ b/alt1/styles/style.css
@@ -713,6 +713,12 @@ small {
     border: none;
     cursor: pointer;
     font-size: 1.2em;
+    padding: 1px 3px !important;
+}
+
+body.dark-mode .info-button, body.dark-mode .reset-button {
+    background: linear-gradient(135deg, #4dabf7, #237abf);
+    color: white;
 }
 
 /* The Modal (hidden by default) */
@@ -919,7 +925,7 @@ body.dark-mode .mod-actions button:hover {
 }
 
 /* Theme toggle switch */
-.theme-switch {
+.switch {
     display: inline-block;
     width: 50px;
     height: 26px;
@@ -927,7 +933,7 @@ body.dark-mode .mod-actions button:hover {
     margin-top: 5px;
 }
 
-.theme-switch input {
+.switch input {
     opacity: 0;
     width: 0;
     height: 0;
@@ -954,10 +960,10 @@ body.dark-mode .mod-actions button:hover {
     border-radius: 50%;
 }
 
-.theme-switch input:checked + .slider {
+.switch input:checked + .slider {
     background: linear-gradient(135deg, #0077cc, #005fa3);
 }
 
-.theme-switch input:checked + .slider::before {
+.switch input:checked + .slider::before {
     transform: translateX(24px);
 }


### PR DESCRIPTION
> This PR is submitted as a suggestion - feel free to ignore or modify as you see fit.

This feature introduces a notification system that triggers upon event processing (`addEvent`) and respects the following constraints:
- Notification Modes
  - Currently two modes, tooltip and toolbar. Each only work in alt1.
    - Tooltip mode will add a tooltip to the cursor when a call that matches the user's preferences is met. The tooltip will last 5 seconds.
    - Toolbar mode will add to the top toolbar. That toolbar will update every 30 seconds to change the remaining time of the event. If a new event matching the user's preference comes in, it will overwrite.
      - Decision was made to update every 30 seconds due to the D&D Notification's Araxxor rotation toolbar being an image and updating the toolbar text causes flashing re-renders. This felt like a good middle ground so there aren't constant flashes, but the time remaining can be close to accurate.
    - Both modes can be selected at the same time. 
- Favorite Events
- Suppression
  - This is selected on the Scouts -> Event History tab as a checkbox called `Toggle notifications today`. The purpose is for users to suppress notifications until daily reset rolls around again. Upon daily reset, this box will auto check off and notifications will send again. It will mostly be useful for users that only are notified for the merchant and have already gotten it that day.
  
Three new UI elements have been added:
- Notifications multiselect (settings tab)
- Notifications information button + modal (settings tab)
- Toggle notifications today checkbox (Scouts -> Event History tab)

Note: If notifications are enabled and the toolbar mode is selected, but none have been received yet, the toolbar will show `Listening for DSF events...`

![image](https://github.com/user-attachments/assets/dc6ec19e-fbe4-41a7-9230-d08818c562a2)
![image](https://github.com/user-attachments/assets/065c5e85-c15a-420f-8880-b5815c519e97)
![image](https://github.com/user-attachments/assets/1792ccce-ba6c-456d-a7c1-297bec7e37c2)
