### PR TITLE
GH workflow deploy fix

### DIFF
--- a/.github/workflows/deploy-on-tag.yml
+++ b/.github/workflows/deploy-on-tag.yml
@@ -3,9 +3,7 @@ name: Deploy on Tag
 on:
   push:
     tags:
-      - 'v*'         # Triggers on any tag starting with v (e.g., v1.1.0)
-    branches:
-      - main         # Ensures tags are pushed to main branch only
+      - 'v*'
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-on-tag.yml
+++ b/.github/workflows/deploy-on-tag.yml
@@ -16,6 +16,16 @@ jobs:
         with:
           fetch-depth: 0  # Ensure all tags are fetched
 
+      - name: Ensure tag is from main
+        run: |
+          git fetch origin main
+          if git merge-base --is-ancestor HEAD origin/main; then
+            echo "✅ Tag commit is part of main."
+          else
+            echo "❌ Tag commit is NOT on main. Failing build."
+            exit 1
+          fi
+
       - name: Set up Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
After reading the docs, having the push on branches didn't scope it to the tag filter AND the branch filter - it was the tag filter OR the branch filter. I have added a step to explicitly check that this runs on tag pushes to the main branch, otherwise fail.