### PR TITLE
Avoid clock drift from server when event.duration = 0

### DIFF
--- a/alt1/scripts/eventHistory.ts
+++ b/alt1/scripts/eventHistory.ts
@@ -702,7 +702,8 @@ export function removeEvent(event: EventRecord): void {
 
 export function getRemainingTime(event: EventRecord): number {
     const now = Date.now();
-    const elapsed = (now - event.timestamp) / 1000;
+    // Avoids clock drift from server when event.duration = 0
+    const elapsed = Math.max((now - event.timestamp) / 1000, 0);
     return event.duration - elapsed;
 }
 


### PR DESCRIPTION
Server and clients can be up to a second off. If this is the case when `event.duration` is 0, the elapsed will be slightly negative which fails the `checkActive` for editing the event.