### PR TITLE
Set the currentWorld before restarting the misty capture

### DIFF
--- a/alt1/scripts/capture.ts
+++ b/alt1/scripts/capture.ts
@@ -367,8 +367,8 @@ async function readChatFromImage(img: a1lib.ImgRefBind): Promise<void> {
         console.log("alt1.currentWorld after world hop and before delay: ", alt1.currentWorld);
         await delay(6000);
         console.log("alt1.currentWorld after world hop and after delay: ", alt1.currentWorld);
-        startCapturingMisty();
         currentWorld = alt1.currentWorld > 0 ? String(alt1.currentWorld) : await findWorldNumber(img);
+        startCapturingMisty();
 
         if (currentWorld && Number(currentWorld) > 0) {
             console.log("World hop message detected and found world number: ", currentWorld);

--- a/alt1/scripts/mistyDialog.ts
+++ b/alt1/scripts/mistyDialog.ts
@@ -82,7 +82,7 @@ async function updateTimersFromMisty(timerData: TimerData): Promise<void> {
               ? String(alt1.currentWorld)
               : await findWorldNumber(a1lib.captureHoldFullRs());
 
-    if (!world) {
+    if (!world || world === "-1") {
         showToast("Misty time not updated - world not found.", "error");
         console.log("Misty time not updated - world not found.");
         return stopCapturingMisty();


### PR DESCRIPTION
Since the world number is used in the mistyDialog script, this makes sure that the `currentWorld` is set based on the new world information before restarting the misty dialog process.