### PR TITLE
When ending event message called, set mistyUpdate to true

### DIFF
--- a/alt1/scripts/capture.ts
+++ b/alt1/scripts/capture.ts
@@ -435,6 +435,7 @@ async function readChatFromImage(img: a1lib.ImgRefBind): Promise<void> {
         eventToEnd.timestamp = Date.now();
         eventToEnd.oldEvent = eventRecordEnding;
         eventToEnd.source = "alt1";
+        eventToEnd.mistyUpdate = true; // Makes sure the discord call is edited
         wsClient.send(eventToEnd);
 
         return;


### PR DESCRIPTION
This allows the bot to receive this event and edit the call in discord if it was initially called via Alt1 webhook.