### PR TITLE
Feat refresh on new version

### DIFF
--- a/alt1/scripts/ws.ts
+++ b/alt1/scripts/ws.ts
@@ -10,6 +10,7 @@ import { WorldRecord } from "./mistyDialog";
 import { notifyEvent } from "./notifications";
 
 type ReceivedData = EventRecord | ProfileRecord | ExpiredTokenRecord | EventRecord[] | WorldEventStatus;
+declare const __APP_VERSION__: string;
 
 const originalConsoleLog = console.log;
 const originalConsoleError = console.error;
@@ -162,6 +163,8 @@ export class WebSocketClient {
                 this.processProfileUpdate(parsedData);
             } else if ("type" in parsedData) {
                 this.processEvent(parsedData);
+            } else if ("version" in parsedData) {
+                if (__APP_VERSION__ !== parsedData.version) window.location.reload();
             } else {
                 await updateWorld(parsedData);
             }

--- a/alt1/scripts/ws.ts
+++ b/alt1/scripts/ws.ts
@@ -9,7 +9,10 @@ import { WorldEventStatus, updateWorld } from "./mistyTimers";
 import { WorldRecord } from "./mistyDialog";
 import { notifyEvent } from "./notifications";
 
-type ReceivedData = EventRecord | ProfileRecord | ExpiredTokenRecord | EventRecord[] | WorldEventStatus;
+interface Version {
+    version: string;
+}
+type ReceivedData = EventRecord | ProfileRecord | ExpiredTokenRecord | EventRecord[] | WorldEventStatus | Version;
 declare const __APP_VERSION__: string;
 
 const originalConsoleLog = console.log;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ const packageJson = require("./package.json");
 
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
+const { DefinePlugin } = require("webpack");
 
 /**
  * @type {(env: { VERSION?: string }) => import("webpack").Configuration}
@@ -50,6 +51,9 @@ module.exports = (env = {}) => {
             new HtmlWebpackPlugin({
                 template: path.resolve(__dirname, "alt1/index.html"),
                 filename: "index.html",
+            }),
+            new DefinePlugin({
+                __APP_VERSION__: JSON.stringify(packageVersion),
             }),
         ],
         module: {


### PR DESCRIPTION
Receive the current version on a client sync event (just after connecting to the websocket). If the client is not on the latest version, then the app reloads.