### PR TITLE
Only run the alt + 1 code if the game is actually in focus

### DIFF
--- a/alt1/scripts/app.ts
+++ b/alt1/scripts/app.ts
@@ -40,7 +40,7 @@ a1lib.on("rsfocus", () => {
 });
 
 a1lib.on("alt1pressed", async () => {
-    await readTextFromDialogBox({ alt1Pressed: true });
+    if (alt1.rsActive) await readTextFromDialogBox({ alt1Pressed: true });
 });
 
 a1lib.on("daemonrun", () => {


### PR DESCRIPTION
The `alt` + `1` keys should only work when the game is in focus so that they only work per client.