### PR TITLE
Don't sent the end event if it wasn't recorded in eventHistory

### DIFF
--- a/alt1/scripts/capture.ts
+++ b/alt1/scripts/capture.ts
@@ -432,9 +432,11 @@ async function readChatFromImage(img: a1lib.ImgRefBind): Promise<void> {
         const eventHistory = JSON.parse(localStorage.getItem("eventHistory") ?? "[]");
         if (!currentWorld) return;
 
+        // Check the event, world, and is within 15 minutes (5 min leeway) to make sure it is the correct one
         const eventRecordEnding = eventHistory
-            .slice(-10)
-            .find((event: EventRecord) => event.world === currentWorld && event.event === endingEvent) as EventRecord;
+            .find((event: EventRecord) => event.world === currentWorld && event.event === endingEvent && (Date.now() - event.timestamp) < 15 * 60 * 1000) as EventRecord;
+
+        if (!eventRecordEnding) return;
         const eventToEnd: EventRecord = { ...eventRecordEnding };
 
         const token = localStorage.getItem("accessToken");


### PR DESCRIPTION
Return if no event record found to prevent error server side. Also add a check to look for events within 15 minutes instead of the last 10 in case of people camping a specific world.