### PR TITLE
Allow time between reloads to cache new content

### DIFF
--- a/alt1/scripts/ws.ts
+++ b/alt1/scripts/ws.ts
@@ -174,7 +174,7 @@ export class WebSocketClient {
             } else if ("version" in parsedData) {
                 if (__APP_VERSION__ !== parsedData.version) {
                     if (!lastReload || Date.now() - Number(lastReload) > 30_000) {
-                        sessionStorage.setItem('lastReload', Date.now().toString());
+                        sessionStorage.setItem("lastReload", Date.now().toString());
                         window.location.reload();
                     }
                 }

--- a/alt1/scripts/ws.ts
+++ b/alt1/scripts/ws.ts
@@ -174,6 +174,7 @@ export class WebSocketClient {
             } else if ("version" in parsedData) {
                 if (__APP_VERSION__ !== parsedData.version) {
                     if (!lastReload || Date.now() - Number(lastReload) > 30_000) {
+                        sessionStorage.setItem('lastReload', Date.now().toString());
                         window.location.reload();
                     }
                 }

--- a/alt1/scripts/ws.ts
+++ b/alt1/scripts/ws.ts
@@ -15,7 +15,7 @@ interface Version {
 type ReceivedData = EventRecord | ProfileRecord | ExpiredTokenRecord | EventRecord[] | WorldEventStatus | Version;
 declare const __APP_VERSION__: string;
 
-const lastReload = sessionStorage.getItem("lastReload");
+// Always read lastReload from sessionStorage when needed
 
 const originalConsoleLog = console.log;
 const originalConsoleError = console.error;
@@ -173,7 +173,8 @@ export class WebSocketClient {
                 this.processEvent(parsedData);
             } else if ("version" in parsedData) {
                 if (__APP_VERSION__ !== parsedData.version) {
-                    if (!lastReload || Date.now() - Number(lastReload) > 30_000) {
+                    const lastReloadTime = sessionStorage.getItem("lastReload");
+                    if (!lastReloadTime || Date.now() - Number(lastReloadTime) > 30_000) {
                         sessionStorage.setItem("lastReload", Date.now().toString());
                         window.location.reload();
                     }

--- a/alt1/scripts/ws.ts
+++ b/alt1/scripts/ws.ts
@@ -15,6 +15,8 @@ interface Version {
 type ReceivedData = EventRecord | ProfileRecord | ExpiredTokenRecord | EventRecord[] | WorldEventStatus | Version;
 declare const __APP_VERSION__: string;
 
+const lastReload = sessionStorage.getItem("lastReload");
+
 const originalConsoleLog = console.log;
 const originalConsoleError = console.error;
 const originalConsoleWarn = console.warn;
@@ -170,7 +172,11 @@ export class WebSocketClient {
             } else if ("type" in parsedData) {
                 this.processEvent(parsedData);
             } else if ("version" in parsedData) {
-                if (__APP_VERSION__ !== parsedData.version) window.location.reload();
+                if (__APP_VERSION__ !== parsedData.version) {
+                    if (!lastReload || Date.now() - Number(lastReload) > 30_000) {
+                        window.location.reload();
+                    }
+                }
             } else {
                 await updateWorld(parsedData);
             }


### PR DESCRIPTION
New reloads sends a SYNC event to the server which fetches the current client version and sends this back. This seems to happen too quickly causing an infinite loop as the client hasn't yet cached the new version.