### PR TITLE
security: send refresh token in request body, not query string

### DIFF
--- a/alt1/scripts/ws.ts
+++ b/alt1/scripts/ws.ts
@@ -53,8 +53,8 @@ export async function refreshToken(): Promise<string | null> {
 
     try {
         const response = await axios.post(
-            `${API_URL}/auth/refresh?token=${refreshToken}`,
-            {},
+            `${API_URL}/auth/refresh`,
+            { token: refreshToken },
             {
                 headers: {
                     "Content-Type": "application/json",


### PR DESCRIPTION
The token refresh request put the refresh token in the URL query string (POST /auth/refresh?token=...). Tokens in query strings leak into server access logs, proxy logs, and browser history. Move it into the JSON request body instead.

BREAKING (backend): requires the /auth/refresh endpoint to read the token from the JSON body ({ "token": ... }) instead of the query parameter. Deploy the backend change together with this.