### PR TITLE
ci: build (type-check + bundle) on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build (type-check + bundle)
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # ts-loader runs a full type-check during the webpack build, so a type
+      # error or compile failure fails this job. This catches breakages on the
+      # PR instead of only at deploy time (build_and_deploy runs on push to main).
+      - name: Build dev bundle
+        run: npm run build:dev


### PR DESCRIPTION
The webpack build is the project's real type-check + compile step (ts-loader type-checks during the build), but it only ran on push to main via build_and_deploy. A PR that broke the build could merge with all checks green and only fail later at deploy.

Add a Build workflow that runs npm run build:dev on PRs to main so type/compile errors are caught before merge.