### PR TITLE
config: derive DEBUG from build mode via DefinePlugin

### DIFF
--- a/alt1/config.ts
+++ b/alt1/config.ts
@@ -1,3 +1,7 @@
-export const DEBUG = false;
+// Injected at build time by webpack's DefinePlugin (see webpack.config.js).
+// true for the local build (build:local / watch), false for alt1 and alt1-dev.
+declare const __DEBUG__: boolean;
+
+export const DEBUG = __DEBUG__;
 export const ORIGIN = DEBUG ? document.location.href : "https://www.dsfeventtracker.com/alt1";
 export const API_URL = DEBUG ? "http://localhost:8000" : "https://api.dsfeventtracker.com";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,6 +60,9 @@ module.exports = (env = {}) => {
             }),
             new DefinePlugin({
                 __APP_VERSION__: JSON.stringify(packageVersion),
+                // Drives config.ts DEBUG off the build mode instead of a hand-edited
+                // constant: true only for the local build (build:local / watch).
+                __DEBUG__: JSON.stringify(isLocal),
             }),
         ],
         module: {


### PR DESCRIPTION
DEBUG was a hand-edited constant in config.ts. Flipping it to true for local dev and forgetting to flip it back risked shipping a production build that points at localhost. Inject __DEBUG__ via webpack DefinePlugin (true only for the local build / watch), mirroring how __APP_VERSION__ is already injected, so the environment follows the build mode instead of a mutable checked-in value.

build:local / watch  -> DEBUG = true  (localhost)
build / build:dev    -> DEBUG = false (production URLs)