### PR TITLE
ci: build production against the tag lockfile to gate dependency updates

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -35,6 +35,11 @@ jobs:
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
 
+      # Build the dev bundle from the current main HEAD using main's deps
+      # (installed above). This is what lands on /alt1-dev for testers.
+      - name: Build alt1-dev version
+        run: npm run build:dev
+
       - name: Build stable version into dist/alt1/
         id: build_stable
         env:
@@ -57,11 +62,13 @@ jobs:
 
           echo "Checking out ${TAG} and building stable…"
           git checkout "$TAG"
+          # Reinstall against the tag's own package-lock.json so production is
+          # built with the dependencies pinned at release time. Without this,
+          # the stable build reuses main's node_modules, so any dependency bump
+          # merged to main would reach production before a version bump.
+          npm ci
           npm run build
           git switch -
-
-      - name: Build alt1-dev version
-        run: npm run build:dev
 
       - name: Deploy to GitHub Pages
         run: |


### PR DESCRIPTION
The deploy ran npm ci on main, then checked out the release tag and ran npm run build without reinstalling. Production /alt1 was therefore built from tagged source but with main's node_modules, so a dependency bump merged to main reached production on the next deploy, before any version bump.

Reorder so the dev bundle builds first (main source + main deps), then the stable build checks out the tag and runs npm ci against the tag's own package-lock.json. Now dependency updates only ship to /alt1-dev on merge and reach production when the version is bumped, matching how source changes are already gated.