### PR TITLE
Fix empty Profile page, post-auth 401s, and Alt1 CSP blocks

### DIFF
--- a/alt1/index.html
+++ b/alt1/index.html
@@ -3,6 +3,20 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <!--
+            Content Security Policy. Alt1 applies a restrictive default CSP (connect-src 'none')
+            to apps, which blocks the API and WebSocket. Declare the origins the app needs here.
+            localhost is included so the local/dev builds (config.ts DEBUG) keep working.
+        -->
+        <meta
+            http-equiv="Content-Security-Policy"
+            content="default-src 'self';
+                     script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://runeapps.org;
+                     style-src 'self' 'unsafe-inline' https://runeapps.org;
+                     img-src 'self' data: blob: https:;
+                     font-src 'self' data: https://runeapps.org;
+                     connect-src 'self' http://localhost:8000 ws://localhost:8000 https://api.dsfeventtracker.com https://ws.dsfeventtracker.com wss://ws.dsfeventtracker.com https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com;"
+        />
         <title>DSF Event Tracker - Alt1 App | RuneScape Deep Sea Fishing Tool</title>
         
         <!-- SEO Meta Tags -->

--- a/alt1/scripts/profile.ts
+++ b/alt1/scripts/profile.ts
@@ -1,4 +1,5 @@
 import { decodeJWT } from "./permissions";
+import { refreshToken } from "./ws";
 import axios from "axios";
 import { API_URL } from "../config";
 
@@ -190,16 +191,42 @@ export async function getEventCountData(): Promise<UpdateFields | null> {
     const discordID = localStorage.getItem("discordID");
     if (!discordID) return null;
 
-    const response = await axios.get(`${API_URL}/profiles/${discordID}`, {
-        headers: {
-            "Content-Type": "application/json",
-        },
-    });
+    // /profiles/{id} is authenticated. Without a token there's nothing to fetch yet —
+    // return quietly instead of firing an unauthenticated request that 401s before the
+    // user has validated.
+    const token = localStorage.getItem("accessToken");
+    if (!token) return null;
 
-    if (response.data.count_data) {
-        console.log("Received event counts");
-        return response.data.count_data;
-    } else {
+    const requestProfile = (authToken: string) =>
+        axios.get(`${API_URL}/profiles/${discordID}`, {
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${authToken}`,
+            },
+        });
+
+    try {
+        let response;
+        try {
+            response = await requestProfile(token);
+        } catch (error) {
+            // Access token likely expired — refresh once and retry before giving up.
+            if (axios.isAxiosError(error) && error.response?.status === 401) {
+                const newToken = await refreshToken();
+                if (!newToken) return null; // No valid session; UI stays in its logged-out state.
+                response = await requestProfile(newToken);
+            } else {
+                throw error;
+            }
+        }
+
+        if (response.data.count_data) {
+            console.log("Received event counts");
+            return response.data.count_data;
+        }
+        return null;
+    } catch (error) {
+        console.error("Failed to load profile event counts:", error);
         return null;
     }
 }

--- a/alt1/scripts/ws.ts
+++ b/alt1/scripts/ws.ts
@@ -53,8 +53,8 @@ export async function refreshToken(): Promise<string | null> {
 
     try {
         const response = await axios.post(
-            `${API_URL}/auth/refresh?token=${refreshToken}`,
-            {},
+            `${API_URL}/auth/refresh`,
+            { token: refreshToken },
             {
                 headers: {
                     "Content-Type": "application/json",


### PR DESCRIPTION
Fixes the empty **Scouts → Profile** page, the post-validation 401s, the pre-validation error spam, and the Alt1 CSP blocks. Diagnosed against production logs + the running backend.

## ① / ② Profile empty & 401s even after validating

`getEventCountData` (`GET /profiles/{discordID}`) sent **no `Authorization` header**, so the authenticated endpoint returned `401` *regardless of a valid token* — which is exactly why validating didn't help. (Server logs showed `Invalid JWT token: Not enough segments`, i.e. no token at all.)

- Attach `Authorization: Bearer <accessToken>`.
- On `401`, refresh the access token once and retry.
- If there's no session, return `null` instead of firing the request / throwing — so the UI stays in its logged-out state.

## ① Errors before the user validates

The profile fetch now no-ops when there's no access token and never throws, so opening the app with no/expired session no longer spams errors.

## ③ Alt1 CSP blocks (`connect-src 'none'`, `script-src …`)

Alt1 applies a restrictive default CSP to apps, which was blocking the API and WebSocket. Added a `Content-Security-Policy` `<meta>` to `alt1/index.html` declaring the origins the app actually uses:

- `connect-src`: `api.dsfeventtracker.com`, `ws.dsfeventtracker.com` / `wss://…`, Google Analytics, **plus `localhost:8000`/`ws://localhost:8000`** so local/dev builds keep working.
- `script-src` / `style-src`: `googletagmanager.com`, `runeapps.org` (NIS), keeping `'unsafe-inline'`/`'unsafe-eval'`.

## Also: stop leaking the refresh token

`refreshToken()` posted to `/auth/refresh?token=<jwt>` (the refresh token ended up in nginx/app access logs). Now sends it in the JSON **body** instead — the backend already accepts both (and the `{}` body that previously caused a 422 is fixed server-side).

## Validation

Production webpack build compiles (types OK), eslint clean. CSP verified present in the built `dist/alt1/index.html`. Couldn't exercise it live inside Alt1 from here — worth a quick smoke test after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
