### PR TITLE
Fix Misty dialog OCR (CSP) and manual timer auth

### DIFF
--- a/alt1/index.html
+++ b/alt1/index.html
@@ -6,16 +6,19 @@
         <!--
             Content Security Policy. Alt1 applies a restrictive default CSP (connect-src 'none')
             to apps, which blocks the API and WebSocket. Declare the origins the app needs here.
-            localhost is included so the local/dev builds (config.ts DEBUG) keep working.
+            cdn.jsdelivr.net is required for the tesseract.js OCR worker, wasm core and language
+            data (Misty dialog capture). localhost is included so the local/dev builds
+            (config.ts DEBUG) keep working.
         -->
         <meta
             http-equiv="Content-Security-Policy"
             content="default-src 'self';
-                     script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://runeapps.org;
+                     script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://runeapps.org https://cdn.jsdelivr.net;
+                     worker-src 'self' blob: https://cdn.jsdelivr.net;
                      style-src 'self' 'unsafe-inline' https://runeapps.org;
                      img-src 'self' data: blob: https:;
                      font-src 'self' data: https://runeapps.org;
-                     connect-src 'self' http://localhost:8000 ws://localhost:8000 https://api.dsfeventtracker.com https://ws.dsfeventtracker.com wss://ws.dsfeventtracker.com https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com;"
+                     connect-src 'self' blob: http://localhost:8000 ws://localhost:8000 https://api.dsfeventtracker.com https://ws.dsfeventtracker.com wss://ws.dsfeventtracker.com https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://cdn.jsdelivr.net;"
         />
         <title>DSF Event Tracker - Alt1 App | RuneScape Deep Sea Fishing Tool</title>
         

--- a/alt1/index.html
+++ b/alt1/index.html
@@ -7,18 +7,19 @@
             Content Security Policy. Alt1 applies a restrictive default CSP (connect-src 'none')
             to apps, which blocks the API and WebSocket. Declare the origins the app needs here.
             cdn.jsdelivr.net is required for the tesseract.js OCR worker, wasm core and language
-            data (Misty dialog capture). localhost is included so the local/dev builds
-            (config.ts DEBUG) keep working.
+            data (Misty dialog capture). cloudflareinsights.com is for the Cloudflare Web
+            Analytics beacon that the CF proxy auto-injects in front of the app. localhost is
+            included so the local/dev builds (config.ts DEBUG) keep working.
         -->
         <meta
             http-equiv="Content-Security-Policy"
             content="default-src 'self';
-                     script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://runeapps.org https://cdn.jsdelivr.net;
+                     script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://runeapps.org https://cdn.jsdelivr.net https://static.cloudflareinsights.com;
                      worker-src 'self' blob: https://cdn.jsdelivr.net;
                      style-src 'self' 'unsafe-inline' https://runeapps.org;
                      img-src 'self' data: blob: https:;
                      font-src 'self' data: https://runeapps.org;
-                     connect-src 'self' blob: http://localhost:8000 ws://localhost:8000 https://api.dsfeventtracker.com https://ws.dsfeventtracker.com wss://ws.dsfeventtracker.com https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://cdn.jsdelivr.net;"
+                     connect-src 'self' blob: http://localhost:8000 ws://localhost:8000 https://api.dsfeventtracker.com https://ws.dsfeventtracker.com wss://ws.dsfeventtracker.com https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://cdn.jsdelivr.net https://cloudflareinsights.com https://static.cloudflareinsights.com;"
         />
         <title>DSF Event Tracker - Alt1 App | RuneScape Deep Sea Fishing Tool</title>
         

--- a/alt1/scripts/mistyTimers.ts
+++ b/alt1/scripts/mistyTimers.ts
@@ -750,12 +750,14 @@ async function editMistyTimer(world: number): Promise<void> {
             return;
         }
 
+        const token = localStorage.getItem("accessToken");
         await axios.patch(
             `${API_URL}/worlds/${world}/event?type=inactive&seconds=${totalSeconds}&editor=Manual`,
             {},
             {
                 headers: {
                     "Content-Type": "application/json",
+                    Authorization: `Bearer ${token}`,
                 },
             },
         );


### PR DESCRIPTION
## Summary

Fixes two user-reported regressions introduced by the recent front/backend updates.

### 1. Cannot capture text from the Misty dialog (OCR)

The Alt1 CSP added in #145 did not account for **tesseract.js**, which powers the Misty dialog OCR. Tesseract loads its worker, wasm core, and `eng` language data from `https://cdn.jsdelivr.net`, which was missing from `script-src`/`connect-src`, and there was no `worker-src` directive — so the browser silently blocked OCR and `worker.recognize()` threw "Unable to capture text from dialog".

- Add `https://cdn.jsdelivr.net` to `script-src` and `connect-src`
- Add `worker-src 'self' blob: https://cdn.jsdelivr.net` (tesseract spawns a blob Web Worker that imports the CDN worker)
- Allow `blob:` in `connect-src`

### 2. Cannot set the Misty timer manually (403)

Backend #57 made `PATCH /worlds/{id}/event` require scouter auth when `editor=Manual`, but `editMistyTimer` sent the request with no `Authorization` header → 403. The OCR-driven path was unaffected (it uses the default `editor=Misty`, which is not gated).

- Attach `Authorization: Bearer <accessToken>` to the manual PATCH, matching the rest of the file.

## Testing

- `tsc --noEmit`: no new errors (only the pre-existing `@types/node`/`webpack.d.ts` duplicate-`require` clash)
- `eslint alt1/scripts/mistyTimers.ts`: clean

## Note

`editMistyTimer` still has no refresh-and-retry on an expired token (unlike `renderMistyTimers`). The missing header fully explains the reported failure; expired-token self-heal could be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
