### PR TITLE
fix(misty): handle errors when saving a manual timer edit

### DIFF
--- a/alt1/scripts/mistyTimers.ts
+++ b/alt1/scripts/mistyTimers.ts
@@ -750,17 +750,65 @@ async function editMistyTimer(world: number): Promise<void> {
             return;
         }
 
-        const token = localStorage.getItem("accessToken");
-        await axios.patch(
-            `${API_URL}/worlds/${world}/event?type=inactive&seconds=${totalSeconds}&editor=Manual`,
-            {},
-            {
-                headers: {
-                    "Content-Type": "application/json",
-                    Authorization: `Bearer ${token}`,
+        const sendManualUpdate = (authToken: string | null) =>
+            axios.patch(
+                `${API_URL}/worlds/${world}/event?type=inactive&seconds=${totalSeconds}&editor=Manual`,
+                {},
+                {
+                    headers: {
+                        "Content-Type": "application/json",
+                        Authorization: `Bearer ${authToken}`,
+                    },
                 },
-            },
-        );
+            );
+
+        const revertCells = (): void => {
+            row.cells[2].textContent = row.dataset.originalStatus || "";
+            row.cells[3].textContent = row.dataset.originalTimer || "";
+        };
+
+        try {
+            await sendManualUpdate(localStorage.getItem("accessToken"));
+        } catch (error) {
+            if (!axios.isAxiosError(error)) {
+                console.error("Unexpected error updating Misty timer", error);
+                revertCells();
+                showToast("Failed to update Misty timer", "error");
+                return;
+            }
+
+            const status = error.response?.status;
+            const message = error.response?.data?.detail;
+
+            // An expired token is swallowed by the backend's optional_scouter dependency,
+            // so the endpoint returns 403 ("Manual edits require scouter permission")
+            // rather than 401. Treat both as a possibly-stale token: refresh once and retry.
+            if (status === 401 || status === 403) {
+                const newToken = await refreshToken();
+                if (!newToken) {
+                    revertCells();
+                    showToast("Session expired. Please re-authenticate.", "error");
+                    return;
+                }
+                try {
+                    await sendManualUpdate(newToken);
+                } catch (retryError) {
+                    console.error(retryError);
+                    const retryMessage = axios.isAxiosError(retryError)
+                        ? retryError.response?.data?.detail
+                        : undefined;
+                    revertCells();
+                    showToast(retryMessage ?? "Failed to update Misty timer", "error");
+                    return;
+                }
+            } else {
+                console.error(error);
+                revertCells();
+                showToast(message ?? "Failed to update Misty timer", "error");
+                return;
+            }
+        }
+
         wsClient.send({ world: Number(world) } as WorldRecord);
         showToast(`Misty time updated for world ${world}`);
         console.log(`Misty time updated for world ${world}`);


### PR DESCRIPTION
## Summary

Adds error handling to `editMistyTimer`'s manual-save PATCH, which previously `await`ed the request with no `try/catch`. Any failure (expired token, network error, backend error) rejected silently — and worse, the table row was left displaying the edited status/timer that was never persisted, so the UI disagreed with the server.

## Changes

- Extract the PATCH into a small `sendManualUpdate(token)` helper.
- Wrap the call in `try/catch`:
  - **On 401/403** → refresh the access token once and retry. The backend's `optional_scouter` dependency swallows an expired-token 401, so the endpoint returns **403** ("Manual edits require scouter permission") rather than 401 — both are treated as a possibly-stale token. If refresh fails, show "Session expired" and revert.
  - **On any other error** → revert the row to its original status/timer and show a toast, so the displayed value matches server state.

## Note on the backend quirk

The 401-vs-403 conflation comes from `optional_scouter` catching the expired-token `HTTPException` and returning `None`, after which the endpoint raises a generic 403. This works with the retry above, but a cleaner long-term fix would be for the backend to surface "token expired" as a 401 so the client can distinguish it from a genuine permission denial. Flagging for a possible follow-up.

## Stacked on #147

This branches off `fix/misty-csp-and-manual-timer-auth` (PR #147), which adds the `Authorization` header this handler builds on. Base will retarget to `main` once #147 merges.

## Testing

- `eslint alt1/scripts/mistyTimers.ts`: clean
- `tsc --noEmit`: no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
