### PR TITLE
chore(misty): retry manual edit only on 401 (after DSF-Server #83)

### DIFF
--- a/alt1/scripts/mistyTimers.ts
+++ b/alt1/scripts/mistyTimers.ts
@@ -780,10 +780,11 @@ async function editMistyTimer(world: number): Promise<void> {
             const status = error.response?.status;
             const message = error.response?.data?.detail;
 
-            // An expired token is swallowed by the backend's optional_scouter dependency,
-            // so the endpoint returns 403 ("Manual edits require scouter permission")
-            // rather than 401. Treat both as a possibly-stale token: refresh once and retry.
-            if (status === 401 || status === 403) {
+            // The backend returns 401 "Token has expired" for a stale token (see
+            // optional_scouter); refresh once and retry. Any other failure (e.g. a
+            // genuine 403 permission denial) is surfaced to the user. Matches the
+            // refresh pattern used in renderMistyTimers and capture.ts.
+            if (status === 401 && message === "Token has expired") {
                 const newToken = await refreshToken();
                 if (!newToken) {
                     revertCells();


### PR DESCRIPTION
## Summary

Follow-up to #149. Now that the backend surfaces an expired token as **401 "Token has expired"** (DSF-Server #83) instead of masking it as a 403, align `editMistyTimer` with the refresh-and-retry pattern already used in `renderMistyTimers` and `capture.ts`:

- **401 "Token has expired"** → refresh the access token once and retry.
- **Any other failure** (including a genuine 403 permission denial) → revert the row and surface the error, instead of pointlessly refreshing on a permission problem.

This replaces the temporary `401 || 403` workaround from #149 that existed only because the backend conflated the two.

## ⚠️ Merge order

**Depends on DSF-Server #83 being _deployed_, not just merged.** If this lands while production still returns 403 for expired tokens, an expired-token manual edit would no longer refresh-and-retry. Merge/deploy this only after #83 is live.

## Testing

- `prettier --check` (3.8.4): clean
- `eslint`: clean
- `tsc --noEmit`: no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
