### PR TITLE
fix(csp): allow data: in connect-src for tesseract wasm

### DIFF
--- a/alt1/index.html
+++ b/alt1/index.html
@@ -7,7 +7,8 @@
             Content Security Policy. Alt1 applies a restrictive default CSP (connect-src 'none')
             to apps, which blocks the API and WebSocket. Declare the origins the app needs here.
             cdn.jsdelivr.net is required for the tesseract.js OCR worker, wasm core and language
-            data (Misty dialog capture). cloudflareinsights.com is for the Cloudflare Web
+            data (Misty dialog capture); the OCR core also instantiates its wasm from a data:
+            URI, so connect-src must allow data:. cloudflareinsights.com is for the Cloudflare Web
             Analytics beacon that the CF proxy auto-injects in front of the app. localhost is
             included so the local/dev builds (config.ts DEBUG) keep working.
         -->
@@ -19,7 +20,7 @@
                      style-src 'self' 'unsafe-inline' https://runeapps.org;
                      img-src 'self' data: blob: https:;
                      font-src 'self' data: https://runeapps.org;
-                     connect-src 'self' blob: http://localhost:8000 ws://localhost:8000 https://api.dsfeventtracker.com https://ws.dsfeventtracker.com wss://ws.dsfeventtracker.com https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://cdn.jsdelivr.net https://cloudflareinsights.com https://static.cloudflareinsights.com;"
+                     connect-src 'self' blob: data: http://localhost:8000 ws://localhost:8000 https://api.dsfeventtracker.com https://ws.dsfeventtracker.com wss://ws.dsfeventtracker.com https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://cdn.jsdelivr.net https://cloudflareinsights.com https://static.cloudflareinsights.com;"
         />
         <title>DSF Event Tracker - Alt1 App | RuneScape Deep Sea Fishing Tool</title>
         


### PR DESCRIPTION
## Summary

The tesseract.js OCR core (`tesseract-core-simd-lstm.wasm.js`) instantiates its WebAssembly module from a `data:application/octet-stream;base64,…` URI. The browser treats loading that URI as a `connect-src` fetch, and `connect-src` did not allow `data:`, so the wasm load was refused:

```
Refused to connect to 'data:application/octet-stream;base64,…' because it violates
the following Content Security Policy directive: "connect-src 'self' blob: …"
```

With the wasm blocked, OCR (Misty dialog capture) cannot run. This adds `data:` to `connect-src`.

## Scope

Not local-only — the CSP `<meta>` is shared across all builds (local/dev/stable), so the same error would hit production once the OCR worker fix is released. Completes the OCR CSP work started in #147 (`worker-src`/`script-src`/jsdelivr).

## Testing

- `eslint` / `prettier` / `tsc`: unaffected (HTML-only change).
- Functional verification pending: rebuild `alt1-local` and confirm the `data:` refusal is gone and the OCR worker recognizes the Misty dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
